### PR TITLE
Fix docker_repository to use the os_release and distribution

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,11 +2,11 @@
 
 docker_os_distribution: "{{ansible_distribution | lower}}"
 docker_os_version: "{{ansible_distribution_major_version}}"
+docker_os_release: "{{ansible_distribution_release}}"
 
 docker_repository_key: "https://apt.dockerproject.org/gpg"
 
-docker_repository: |
-  deb https://apt.dockerproject.org/repo ubuntu-precise main
+docker_repository: "deb https://apt.dockerproject.org/repo {{docker_os_distribution}}-{{docker_os_release}} main"
 
 docker_packages:
   - docker-engine


### PR DESCRIPTION
since the repo url was pointing to ubuntu-precise, there were some issues with the new LTS release using systemD instead of upstart.

This PR includes a simple fix to construct the repo URL based on the os_distribution and release.